### PR TITLE
added excel export

### DIFF
--- a/backend/core/projection.py
+++ b/backend/core/projection.py
@@ -90,7 +90,7 @@ def _make_intervals(
     out: List[Tuple[int, int, ContributionBreakpoint]] = []
     for i, row in enumerate(rows_sorted):
         next_start = rows_sorted[i + 1].fromAge if i + 1 < len(rows_sorted) else stop_age
-        # if years is None, run until the next breakpoint; else for `years` years
+        # if years is None, run until the next breakpoint; else for yearss
         end = row.fromAge + (row.years if row.years is not None else max(next_start - row.fromAge, 0))
         if end <= row.fromAge:  # guard against weird inputs
             end = next_start
@@ -165,7 +165,7 @@ def project_savings_table(
         bal_avg *= (1.0 + gavg)
         bal_max *= (1.0 + gmax)
 
-        # 3) record row (rounded a bit for nice output)
+        # 3) record row (rounded a bit for nice output/dollar)
         rows.append(
             YearRow(
                 age=age,
@@ -192,20 +192,20 @@ def project_savings_with_retirement(
     spending_change_yoy: float = 0.0,  # extra real change; 0 = same lifestyle in real terms
 ) -> List[YearRowWithSpending]:
     """
-    Uses all your existing structures, but extends past retirement and applies drawdown.
+    Uses all existing structures, but extends past retirement and applies drawdown.
 
     Conventions:
       - Working years (age < retirementAge):
-            1) Contribution at START of year  (same as your current function)
+            1) Contribution at START of year  (same as current function)
             2) Then apply growth.
       - Retirement years (age >= retirementAge):
             1) Compute spending from retirementSpendingRaw (today's $), per band.
             2) Subtract spending at START of year (can go negative).
             3) Then apply growth.
       - Band pairing:
-            Min  = worst case  = low growth + HIGH inflation (max drawdown)
-            Avg  = middle      = avg growth + avg inflation
-            Max  = best case   = high growth + LOW inflation (light drawdown)
+            Min = worst case = low growth + HIGH inflation (max drawdown)
+            Avg = middle = avg growth + avg inflation
+            Max = best case = high growth + LOW inflation (light drawdown)
     """
 
     s = assumptions.to_scenarios()
@@ -265,7 +265,7 @@ def project_savings_with_retirement(
 
         # ---------- Working years ----------
         if age < basic.retirementAge:
-            # 1) Contribution at START of year (same as your existing logic)
+            # 1) Contribution at START of year (same as existing logic)
             rule = _active_row(intervals, age)
             if rule:
                 t = age - rule.fromAge  # years since this breakpoint began

--- a/frontend/src/components/ExportCard.tsx
+++ b/frontend/src/components/ExportCard.tsx
@@ -1,0 +1,49 @@
+import { useMemo } from "react";
+
+import { exportPlanToExcel } from "../lib/exportExcel";
+import type { ProjectionRow } from "../lib/api";
+import type { Plan } from "../lib/schemas";
+
+interface ExportCardProps {
+  plan: Plan;
+  rows: ProjectionRow[];
+  loading?: boolean;
+}
+
+export function ExportCard({ plan, rows, loading }: ExportCardProps) {
+  const disabled = loading || rows.length === 0;
+  const helperText = useMemo(() => {
+    if (loading) return "Crunching numbers… export will unlock when ready.";
+    if (!rows.length) return "Generate a projection to enable export.";
+    return "Download every year and calculation as an Excel file.";
+  }, [loading, rows.length]);
+
+  const handleExport = () => {
+    if (disabled) return;
+    try {
+      exportPlanToExcel(plan, rows);
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error(err);
+    }
+  };
+
+  return (
+    <section className="rounded-3xl border border-slate-300 bg-white p-5 shadow-sm">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h3 className="text-sm font-semibold text-slate-800">Export</h3>
+          <p className="text-xs text-slate-500">{helperText}</p>
+        </div>
+        <button
+          type="button"
+          onClick={handleExport}
+          disabled={disabled}
+          className="rounded-2xl bg-emerald-600 px-3 py-2 text-xs font-semibold text-white shadow hover:bg-emerald-500 disabled:cursor-not-allowed disabled:bg-slate-300"
+        >
+          Export to Excel
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -14,6 +14,7 @@ body {
   appearance: none;
   background: transparent;
   cursor: pointer;
+  pointer-events: none; /* avoid stacking conflicts; thumbs remain interactive */
 }
 
 .range-input:disabled {
@@ -34,6 +35,7 @@ body {
   border: 2px solid #ffffff;
   margin-top: -7px;
   box-shadow: 0 0 0 1px rgba(15, 23, 42, 0.15);
+  pointer-events: auto;
 }
 
 .range-input::-moz-range-track {
@@ -48,4 +50,5 @@ body {
   background: #0f172a;
   border: 2px solid #ffffff;
   box-shadow: 0 0 0 1px rgba(15, 23, 42, 0.15);
+  pointer-events: auto;
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -16,7 +16,7 @@ interface ScenarioTriple {
   max: number;
 }
 
-interface ProjectionRow {
+export interface ProjectionRow {
   age: number;
   year: number;
   contribution: number;
@@ -53,6 +53,7 @@ interface ProjectionRequestPayload {
 export interface ProjectionResult {
   cases: ProjectionCase[];
   warnings: string[];
+  rows: ProjectionRow[];
 }
 
 export async function runProjection(plan: Plan): Promise<ProjectionResult> {
@@ -65,6 +66,7 @@ export async function runProjection(plan: Plan): Promise<ProjectionResult> {
   return {
     cases: rowsToCases(rows, inflation),
     warnings: [],
+    rows,
   };
 }
 

--- a/frontend/src/lib/exportExcel.ts
+++ b/frontend/src/lib/exportExcel.ts
@@ -1,0 +1,184 @@
+import { formatCurrency } from "./calc";
+import { formatPercentage } from "./number-format";
+import type { ProjectionRow } from "./api";
+import type { Account, Plan, SpendingRow } from "./schemas";
+
+function escapeHtml(value: string): string {
+  return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+function makeTable(headers: string[], rows: Array<Array<string | number>>): string {
+  const headerRow = `<tr>${headers.map((h) => `<th>${escapeHtml(h)}</th>`).join("")}</tr>`;
+  const bodyRows = rows
+    .map(
+      (cells) =>
+        `<tr>${cells
+          .map((cell) => `<td>${typeof cell === "number" ? cell : escapeHtml(cell)}</td>`)
+          .join("")}</tr>`,
+    )
+    .join("");
+  return `<table>${headerRow}${bodyRows}</table>`;
+}
+
+function summarizeSavings(accounts: Account[]): string {
+  if (!accounts.length) return "No accounts configured";
+  return accounts
+    .map((account, index) => {
+      const label = `${account.label || "Account"} (#${index + 1})`;
+      if (!account.contributions.length) {
+        return `${label}: no scheduled contributions`;
+      }
+      const rows = account.contributions
+        .map((row) => {
+          const years = row.years ?? "until next breakpoint/retirement";
+          return `From age ${row.fromAge}, ${formatCurrency(row.base)} per year, growth ${formatPercentage(row.growthRate)}, years ${years}`;
+        })
+        .join("; ");
+      return `${label}: ${rows}`;
+    })
+    .join("<br/>");
+}
+
+function spendingRowLabel(row: SpendingRow, startAge: number, inflation: number): string {
+  const endAge = row.years ? row.fromAge + row.years : undefined;
+  const yearsAhead = Math.max(row.fromAge - startAge, 0);
+  const futureValue = row.annualSpending * Math.pow(1 + inflation, yearsAhead);
+  const rangeLabel = endAge ? `Age ${row.fromAge}-${endAge}` : `Age ${row.fromAge}+`;
+  return `${rangeLabel}: ${formatCurrency(row.annualSpending)} / yr today ≈ ${formatCurrency(futureValue)} nominal`;
+}
+
+function makeProjectionTable(rows: ProjectionRow[]): string {
+  const headers = [
+    "Age",
+    "Contribution",
+    "Spending (min)",
+    "Spending (avg)",
+    "Spending (max)",
+    "Savings (min)",
+    "Savings (avg)",
+    "Savings (max)",
+  ];
+
+  const body = rows.map((row) => [
+    row.age,
+    formatCurrency(row.contribution),
+    formatCurrency(row.spending.min),
+    formatCurrency(row.spending.avg),
+    formatCurrency(row.spending.max),
+    formatCurrency(row.savings.min),
+    formatCurrency(row.savings.avg),
+    formatCurrency(row.savings.max),
+  ]);
+
+  return makeTable(headers, body);
+}
+
+export function exportPlanToExcel(plan: Plan, rows: ProjectionRow[]): void {
+  if (!rows.length) {
+    throw new Error("No projection data to export. Run a calculation first.");
+  }
+
+  const growthBand = {
+    min: plan.investmentGrowthRate - plan.investmentGrowthMargin,
+    avg: plan.investmentGrowthRate,
+    max: plan.investmentGrowthRate + plan.investmentGrowthMargin,
+  };
+
+  const inflationBand = {
+    min: Math.max(plan.inflationRate - plan.inflationMargin, 0),
+    avg: plan.inflationRate,
+    max: plan.inflationRate + plan.inflationMargin,
+  };
+
+  const basics = makeTable(
+    ["Basic Information", "Value"],
+    [
+      ["Current Age", plan.startAge],
+      ["Retirement Age", plan.retireAge],
+      ["Current Savings", formatCurrency(plan.initialBalance ?? 0)],
+      ["Desired Annual Retirement Spending", formatCurrency(plan.startingRetirementSpending ?? 0)],
+    ],
+  );
+
+  const assumptions = makeTable(
+    ["Growth Assumptions", "Value"],
+    [
+      ["Annual Inflation", formatPercentage(plan.inflationRate)],
+      ["Inflation Error Margin", formatPercentage(plan.inflationMargin)],
+      ["Investment Growth Rate", formatPercentage(plan.investmentGrowthRate)],
+      ["Investment Error Margin", formatPercentage(plan.investmentGrowthMargin)],
+    ],
+  );
+
+  const savingsSummary = makeTable(
+    ["Edit Savings Progression", "Details"],
+    [[`Accounts (${plan.accounts.length || 0})`, summarizeSavings(plan.accounts)]],
+  );
+
+  const spendingRows =
+    plan.spendingSchedule.length === 0
+      ? [["Schedule", "No retirement spending overrides"]]
+      : plan.spendingSchedule
+          .slice()
+          .sort((a, b) => a.fromAge - b.fromAge)
+          .map((row, index) => [
+            `Edit Retirement Spending (${index + 1})`,
+            spendingRowLabel(row, plan.startAge, plan.inflationRate),
+          ]);
+  const spendingTable = makeTable(["Edit Retirement Spending", "Details"], spendingRows);
+
+  const calculations = makeTable(
+    ["Calculations", "min", "avg", "max"],
+    [
+      [
+        "Growth",
+        formatPercentage(growthBand.min),
+        formatPercentage(growthBand.avg),
+        formatPercentage(growthBand.max),
+      ],
+      [
+        "Inflation",
+        formatPercentage(inflationBand.min),
+        formatPercentage(inflationBand.avg),
+        formatPercentage(inflationBand.max),
+      ],
+    ],
+  );
+
+  const projectionTable = makeProjectionTable(rows);
+
+  const html = `
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Projection Export</title>
+    <style>
+      body { font-size: 10pt; }
+      table { border-collapse: collapse; margin: 8px 0; }
+      th, td { padding: 2px 4px; }
+    </style>
+  </head>
+  <body>
+    <div>Detailed Compound Interest Calculator Export</div>
+    <div>Snapshot of your current inputs, assumptions, and full projection timeline.</div>
+    ${basics}
+    ${assumptions}
+    ${savingsSummary}
+    ${spendingTable}
+    ${calculations}
+    <div>Full Projection (all years)</div>
+    ${projectionTable}
+  </body>
+</html>
+  `;
+
+  const blob = new Blob([html], { type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = "projection-export.xlsx";
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
Mostly for debugging, added Excel export button. Exports graph contents as numbers and input numbers by user. Ideally, will expand this to include line items for main things (savings and retirement spending groups) and formulas if possible.

Related to Issue #3 